### PR TITLE
Fix bug where task resolution tries to equate strings and projects

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "365895d4-76a3-41be-91f3-79ee45426e42"
+type = "fix"
+description = "Fix bug where task resolution tries to equate strings and projects"
+author = "@tetigi"

--- a/src/kraken/core/context.py
+++ b/src/kraken/core/context.py
@@ -183,7 +183,7 @@ class Context(MetadataContainer, Currentable["Context"]):
                 parts.pop(0)
             while parts:
                 project_children = project.children()
-                if parts[0] in project_children.values():
+                if parts[0] in project_children:
                     project = project_children[parts.pop(0)]
                 else:
                     break


### PR DESCRIPTION
`project.children().values()` is a list of projects, and `parts[0]` is a string.